### PR TITLE
Fix a typo in item view

### DIFF
--- a/src/app/views/items/view.blade.php
+++ b/src/app/views/items/view.blade.php
@@ -150,7 +150,7 @@
       &nbsp;&nbsp;&nbsp;
       Fire: {{{  $item->protection('fire') }}}
       Elec: {{{  $item->protection('elec') }}}<br>
-      Environmental protection: {{{ $item->enviromental_protection }}}<br>
+      Environmental protection: {{{ $item->environmental_protection }}}<br>
       Warmth: {{{ $item->warmth }}}<br>
       Storage: {{{ $item->storage }}}<br>
     @endif


### PR DESCRIPTION
My guess is that this is causing the lack of display of environmental
production on "stable", but without knowing exactly how items are
populated and without being able to find any migrations, I can't know for
sure. Regardless, it's a typo.
