### PR TITLE
Fix incorrect volume for containers

### DIFF
--- a/src/app/models/Item.php
+++ b/src/app/models/Item.php
@@ -418,7 +418,7 @@ class Item implements Robbo\Presenter\PresentableInterface
 
     public function getContains()
     {
-        return $this->data->contains/4.0;
+        return $this->data->contains;
     }
 
     public function getConstructionUses()


### PR DESCRIPTION
60L tanks can store 60L, not 15. Ezpz fix, volume changed sometime to be more sane.

![screenshot_2017-05-20_21-51-19](https://cloud.githubusercontent.com/assets/18541270/26280772/82527606-3da6-11e7-95b8-04580860c74f.png)
